### PR TITLE
Add pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm", "numpy"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     description="""SplineCalib is a Python package for calibrating
                    ML models using smoothing splines.  See documentation at:
                    https://splinecalib.readthedocs.io/""",
-    version='0.0.2',
+    version='0.0.3',
     long_description=README,
     url='https://github.com/numeristical/splinecalib',
     packages=['splinecalib'],


### PR DESCRIPTION
The setup requires numpy, so we need to tell python that. This is to adhere with https://peps.python.org/pep-0517/

After this update, you will be able to use other build tools such as `poetry` to install the package.